### PR TITLE
Update CrudOperationsTrait.php

### DIFF
--- a/src/Controller/Traits/CrudOperationsTrait.php
+++ b/src/Controller/Traits/CrudOperationsTrait.php
@@ -67,7 +67,7 @@ trait CrudOperationsTrait
     {
         $pagination = [
             'limit' => $this->hasJraOption('pagination.limit') ? $this->getJraOption('pagination.limit') : 50,
-            'page' => ($this->request->query('page') === null) ? 0 : $this->request->query('page')
+            'page' => ($this->request->query('page') === null) ? 1 : $this->request->query('page')
         ];
 
         $resources = $this->findResources($pagination);


### PR DESCRIPTION
having 0 for default page value generates an SQL OFFSET error by putting negative value.
This can be solve by setting 1 as default value for page function call.